### PR TITLE
Fix an issue when there is a null as the value in provided json

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/JsonTokenizerStreamProcessorFunction.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/JsonTokenizerStreamProcessorFunction.java
@@ -19,6 +19,7 @@
 package org.wso2.extension.siddhi.execution.json;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -95,7 +96,7 @@ import java.util.Map;
 )
 public class JsonTokenizerStreamProcessorFunction extends StreamProcessor {
     private static final Logger log = Logger.getLogger(JsonTokenizerStreamProcessorFunction.class);
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
     private boolean failOnMissingAttribute = true;
 
     @Override

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetStringJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetStringJSONFunctionExtension.java
@@ -19,6 +19,7 @@
 package org.wso2.extension.siddhi.execution.json.function;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -66,7 +67,7 @@ import java.util.Map;
 )
 public class GetStringJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetStringJSONFunctionExtension.class);
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/InsertToJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/InsertToJSONFunctionExtension.java
@@ -19,6 +19,7 @@
 package org.wso2.extension.siddhi.execution.json.function;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidModificationException;
 import com.jayway.jsonpath.JsonPath;
@@ -79,7 +80,7 @@ import java.util.Map;
 )
 public class InsertToJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(InsertToJSONFunctionExtension.class);
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/ToJSONStringFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/ToJSONStringFunctionExtension.java
@@ -19,6 +19,7 @@
 package org.wso2.extension.siddhi.execution.json.function;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.log4j.Logger;
 import org.wso2.siddhi.annotation.Example;
 import org.wso2.siddhi.annotation.Extension;
@@ -60,7 +61,7 @@ import java.util.Map;
 )
 public class ToJSONStringFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(ToJSONStringFunctionExtension.class);
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate


### PR DESCRIPTION
When there is a null as the value for a particular JSON key, default gson implementation will drop both key and value from the output.