### PR TITLE
Fix issue in getting the input JSON as Object

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/JsonTokenizerAsObjectStreamProcessorFunction.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/JsonTokenizerAsObjectStreamProcessorFunction.java
@@ -18,6 +18,7 @@
 
 package org.wso2.extension.siddhi.execution.json;
 
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -31,6 +32,7 @@ import org.wso2.siddhi.core.event.ComplexEventChunk;
 import org.wso2.siddhi.core.event.stream.StreamEvent;
 import org.wso2.siddhi.core.event.stream.StreamEventCloner;
 import org.wso2.siddhi.core.event.stream.populater.ComplexEventPopulater;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ConstantExpressionExecutor;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.query.processor.Processor;
@@ -114,6 +116,8 @@ public class JsonTokenizerAsObjectStreamProcessorFunction extends StreamProcesso
             } catch (PathNotFoundException e) {
                 filteredJsonElements = null;
                 log.warn("Cannot find json element for the path '" + path + "' in the input json : " + jsonInput);
+            } catch (InvalidJsonException e) {
+                throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
             }
             if (filteredJsonElements instanceof List) {
                 List filteredJsonElementsList = (List) filteredJsonElements;

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetBoolJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetBoolJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -67,10 +71,11 @@ import java.util.Map;
                         "insert into OutputStream;",
                 description = "This returns the boolean value of the JSON input in the given path. The results are " +
                         "directed to the 'OutputStream' stream."
-)
+        )
 )
 public class GetBoolJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetBoolJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -121,7 +126,12 @@ public class GetBoolJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object filteredJsonElement = null;
         Boolean returnValue;
@@ -130,6 +140,8 @@ public class GetBoolJSONFunctionExtension extends FunctionExecutor {
         } catch (PathNotFoundException e) {
             log.error("Cannot find the json element for the path '" + path + "'. Hence it returns" +
                     "the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (filteredJsonElement instanceof List) {
             if (((List) filteredJsonElement).size() != 1) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetDoubleJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetDoubleJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -69,6 +73,7 @@ import java.util.Map;
 )
 public class GetDoubleJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetDoubleJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -119,7 +124,12 @@ public class GetDoubleJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object filteredJsonElement = null;
         Double returnValue;
@@ -128,6 +138,8 @@ public class GetDoubleJSONFunctionExtension extends FunctionExecutor {
         } catch (PathNotFoundException e) {
             log.error("Cannot find json element for the path '" + path + "'. Hence it returns the default value, " +
                     "'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (filteredJsonElement instanceof List) {
             if (((List) filteredJsonElement).size() != 1) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetFloatJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetFloatJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -70,6 +74,7 @@ import java.util.Map;
 )
 public class GetFloatJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetFloatJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -120,7 +125,12 @@ public class GetFloatJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object filteredJsonElement = null;
         Float returnValue;
@@ -128,6 +138,8 @@ public class GetFloatJSONFunctionExtension extends FunctionExecutor {
             filteredJsonElement = JsonPath.read(jsonInput, path);
         } catch (PathNotFoundException e) {
             log.error("Cannot find json element for the path '" + path + "'. Hence returning the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (filteredJsonElement instanceof List) {
             if (((List) filteredJsonElement).size() != 1) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetIntJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetIntJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -70,6 +74,7 @@ import java.util.Map;
 )
 public class GetIntJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetIntJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -120,7 +125,12 @@ public class GetIntJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object filteredJsonElement = null;
         Integer returnValue;
@@ -128,6 +138,8 @@ public class GetIntJSONFunctionExtension extends FunctionExecutor {
             filteredJsonElement = JsonPath.read(jsonInput, path);
         } catch (PathNotFoundException e) {
             log.error("Cannot find json element for the path '" + path + "'. Hence returning the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (filteredJsonElement instanceof List) {
             if (((List) filteredJsonElement).size() != 1) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetLongJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetLongJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -70,6 +74,7 @@ import java.util.Map;
 )
 public class GetLongJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetLongJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -120,7 +125,12 @@ public class GetLongJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object filteredJsonElement = null;
         Long returnValue;
@@ -128,6 +138,8 @@ public class GetLongJSONFunctionExtension extends FunctionExecutor {
             filteredJsonElement = JsonPath.read(jsonInput, path);
         } catch (PathNotFoundException e) {
             log.error("Cannot find json element for the path '" + path + "'. Hence returning the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (filteredJsonElement instanceof List) {
             if (((List) filteredJsonElement).size() != 1) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetObjectJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetObjectJSONFunctionExtension.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json.function;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -27,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -68,6 +72,7 @@ import java.util.Map;
 )
 public class GetObjectJSONFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(GetObjectJSONFunctionExtension.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
     /**
      * The initialization method for {@link FunctionExecutor}, which will be called before other methods and validate
@@ -118,20 +123,23 @@ public class GetObjectJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object returnValue = null;
         try {
             returnValue = JsonPath.read(jsonInput, path);
         } catch (PathNotFoundException e) {
             log.warn("Cannot find json element for the path '" + path + "'. Hence returning the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (returnValue instanceof List) {
-            if (((List) returnValue).size() != 1) {
-                returnValue = null;
-                log.warn("Multiple matches or No matches for the given path '" + path + "' in input json. Please use " +
-                        "valid path which provide exact one match in the given json");
-            } else {
+            if (((List) returnValue).size() == 1) {
                 returnValue = ((List) returnValue).get(0);
             }
         }

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetStringJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/GetStringJSONFunctionExtension.java
@@ -20,6 +20,7 @@ package org.wso2.extension.siddhi.execution.json.function;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.apache.log4j.Logger;
@@ -29,6 +30,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -120,13 +122,21 @@ public class GetStringJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object returnValue = null;
         try {
             returnValue = JsonPath.read(jsonInput, path);
         } catch (PathNotFoundException e) {
             log.warn("Cannot find json element for the path '" + path + "'. Hence returning the default value 'null'");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (returnValue == null) {
             return null;

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/InsertToJSONFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/json/function/InsertToJSONFunctionExtension.java
@@ -21,6 +21,7 @@ package org.wso2.extension.siddhi.execution.json.function;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.InvalidModificationException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
@@ -31,6 +32,7 @@ import org.wso2.siddhi.annotation.Parameter;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
@@ -152,7 +154,12 @@ public class InsertToJSONFunctionExtension extends FunctionExecutor {
      */
     @Override
     protected Object execute(Object[] data) {
-        String jsonInput = data[0].toString();
+        String jsonInput;
+        if (data[0] instanceof String) {
+            jsonInput = (String) data[0];
+        } else {
+            jsonInput = gson.toJson(data[0]);
+        }
         String path = data[1].toString();
         Object jsonElement = data[2];
         String key = null;
@@ -166,6 +173,8 @@ public class InsertToJSONFunctionExtension extends FunctionExecutor {
         } catch (PathNotFoundException e) {
             log.warn("The path '" + path + "' is not a valid path for the json '" + jsonInput + "'. Please provide a" +
                     " valid path.");
+        } catch (InvalidJsonException e) {
+            throw new SiddhiAppRuntimeException("The input JSON is not a valid JSON. Input JSON - " + jsonInput, e);
         }
         if (object instanceof List) {
             try {

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/json/GetBoolJSONFunctionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/json/GetBoolJSONFunctionTestCase.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json;
 
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
@@ -81,6 +84,51 @@ public class GetBoolJSONFunctionTestCase {
         inputHandler.send(new Object[]{JSON_INPUT, "$.citizen"});
         inputHandler.send(new Object[]{JSON_INPUT, "$.name"});
         inputHandler.send(new Object[]{JSON_INPUT, "$.xyz"});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testGetBoolFromJSON2() throws InterruptedException, ParseException {
+        log.info("GetBoolJSONFunctionExtension - testGetBoolFromJSON");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(json object,path string);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:getBool(json,path) as married\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals(true, event.getData(0));
+                            break;
+                        case 2:
+                            AssertJUnit.assertEquals(false, event.getData(0));
+                            break;
+                        case 3:
+                            AssertJUnit.assertEquals(false, event.getData(0));
+                            break;
+                        case 4:
+                            AssertJUnit.assertEquals(false, event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(JSON_INPUT);
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{jsonObject, "$.married"});
+        inputHandler.send(new Object[]{jsonObject, "$.citizen"});
+        inputHandler.send(new Object[]{jsonObject, "$.name"});
+        inputHandler.send(new Object[]{jsonObject, "$.xyz"});
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/json/GetObjectJSONFunctionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/json/GetObjectJSONFunctionTestCase.java
@@ -18,6 +18,9 @@
 
 package org.wso2.extension.siddhi.execution.json;
 
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeMethod;
@@ -81,6 +84,51 @@ public class GetObjectJSONFunctionTestCase {
         inputHandler.send(new Object[]{JSON_INPUT, "$.citizen"});
         inputHandler.send(new Object[]{JSON_INPUT, "$.name"});
         inputHandler.send(new Object[]{JSON_INPUT, "$.married"});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testGetObjectFromJSON2() throws InterruptedException, ParseException {
+        log.info("GetObjectJSONFunctionTestCase - testGetObjectFromJSON");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(json object,path string);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:getObject(json,path) as married\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals(25, event.getData(0));
+                            break;
+                        case 2:
+                            AssertJUnit.assertEquals(false, event.getData(0));
+                            break;
+                        case 3:
+                            AssertJUnit.assertEquals("John", event.getData(0));
+                            break;
+                        case 4:
+                            AssertJUnit.assertEquals(null, event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(JSON_INPUT);
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{jsonObject, "$.age"});
+        inputHandler.send(new Object[]{jsonObject, "$.citizen"});
+        inputHandler.send(new Object[]{jsonObject, "$.name"});
+        inputHandler.send(new Object[]{jsonObject, "$.married"});
         siddhiAppRuntime.shutdown();
     }
 }


### PR DESCRIPTION
## Purpose
Fix issue in getting the input JSON as Object. When the input JSON is provided as an object, the extension is not working correctly. Because it is using toString function to convert the object into String.

## Goals
Fix issue in getting the input JSON as Object.

## Approach
Remove the toString function and use gson.toJSON function to convert the jsonObject to String

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_191"
Java(TM) SE Runtime Environment (build 1.8.0_191-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.191-b12, mixed mode)
 
## Learning
NA