### PR TITLE
Add JSON grouping support #24

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAggregatorFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAggregatorFunctionExtension.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.execution.json.function;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.annotation.Parameter;
+import io.siddhi.annotation.ParameterOverload;
+import io.siddhi.annotation.ReturnAttribute;
+import io.siddhi.annotation.util.DataType;
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.executor.ExpressionExecutor;
+import io.siddhi.core.query.processor.ProcessingMode;
+import io.siddhi.core.query.selector.attribute.aggregator.AttributeAggregatorExecutor;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.query.api.definition.Attribute;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.siddhi.query.api.definition.Attribute.Type.OBJECT;
+
+/**
+ * group(json, enclosing.element)
+ * Returns JSON object by merging all JSON elements if enclosing element is provided.
+ * Returns a JSON array by adding all JSON elements if enclosing element is not provided
+ */
+@Extension(
+        name = "group",
+        namespace = "json",
+        description = "This function aggregates the JSON elements and returns a JSON object by adding " +
+                "enclosing.element if it is provided. If enclosing.element is not provided it aggregate the JSON " +
+                "elements returns a JSON array.",
+        parameters = {
+                @Parameter(name = "json",
+                        description = "The JSON element that needs to be aggregated.",
+                        type = {DataType.STRING},
+                        dynamic = true),
+                @Parameter(name = "enclosing.element",
+                        description = "The JSON element used to enclose the aggregated JSON elements.",
+                        type = {DataType.STRING}, optional = true, defaultValue = "EMPTY_STRING", dynamic = true),
+                @Parameter(name = "distinct",
+                        description = "This is used to only have distinct JSON elements in the concatenated " +
+                                "JSON object/array that is returned.",
+                        type = {DataType.BOOL}, optional = true, defaultValue = "false", dynamic = true)
+        },
+        parameterOverloads = {
+                @ParameterOverload(parameterNames = {"json"}),
+                @ParameterOverload(parameterNames = {"json", "distinct"}),
+                @ParameterOverload(parameterNames = {"json", "enclosing.element"}),
+                @ParameterOverload(parameterNames = {"json", "enclosing.element", "distinct"})
+        },
+        returnAttributes = @ReturnAttribute(
+                description = "This returns a JSON object if enclosing element is provided. If there is no enclosing " +
+                        "element then it returns a JSON array.",
+                type = {DataType.OBJECT}),
+        examples = {
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\") as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"12:20\"}`, it" +
+                                " returns `[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}" +
+                                "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}]` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", true) as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}`, it" +
+                                " returns `[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}]` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", \"result\") as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"12:20\"}`, it" +
+                                " returns `{\"result\":[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}," +
+                                "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}}` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", \"result\", true) as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}`, it" +
+                                " returns `{\"result\":[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}]}` " +
+                                "to the 'OutputStream'.")
+        }
+
+)
+public class GroupAggregatorFunctionExtension
+        extends AttributeAggregatorExecutor<GroupAggregatorFunctionExtension.ExtensionState> {
+
+    private static final String KEY_DATA_MAP = "dataMap";
+    private Map<Object, Integer> dataMap = new LinkedHashMap<>();
+
+    @Override
+    protected StateFactory<ExtensionState> init(ExpressionExecutor[] expressionExecutors,
+                                                ProcessingMode processingMode,
+                                                boolean b,
+                                                ConfigReader configReader,
+                                                SiddhiQueryContext siddhiQueryContext) {
+        return () -> new ExtensionState();
+    }
+
+    @Override
+    public Object processAdd(Object o, ExtensionState extensionState) {
+        addJSONElement(o);
+        return constructJSONObject(null, false);
+    }
+
+    @Override
+    public Object processAdd(Object[] objects, ExtensionState extensionState) {
+        addJSONElement(objects[0]);
+        return processJSONObject(objects);
+    }
+
+    @Override
+    public Object processRemove(Object o, ExtensionState extensionState) {
+        removeJSONElement(o);
+        return constructJSONObject(null, false);
+    }
+
+    @Override
+    public Object processRemove(Object[] objects, ExtensionState extensionState) {
+        removeJSONElement(objects[0]);
+        return processJSONObject(objects);
+    }
+
+    @Override
+    public Object reset(ExtensionState extensionState) {
+        dataMap.clear();
+        return null;
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return OBJECT;
+    }
+
+    private Object processJSONObject(Object[] objects) {
+        if (objects.length == 3) {
+            return constructJSONObject(objects[1].toString(), Boolean.parseBoolean(objects[2].toString()));
+        } else {
+            if (objects[1] instanceof Boolean) {
+                return constructJSONObject(null, Boolean.parseBoolean(objects[1].toString()));
+            } else {
+                return constructJSONObject(objects[1].toString(), false);
+            }
+        }
+
+    }
+
+    private void addJSONElement(Object json) {
+        Integer count = dataMap.get(json);
+        dataMap.put(json, (count == null) ? 1 : count + 1);
+    }
+
+    private void removeJSONElement(Object json) {
+        Integer count = dataMap.get(json);
+        if (count == 1) {
+            dataMap.remove(json);
+        } else if (count > 1) {
+            dataMap.put(json, count - 1);
+        }
+    }
+
+    private Object constructJSONObject(String enclosingElement, boolean isDistinct) {
+        JSONArray jsonArray = new JSONArray();
+        if (!isDistinct) {
+            for (Map.Entry<Object, Integer> entry : dataMap.entrySet()) {
+                for (int i = 0; i < entry.getValue(); i++) {
+                    jsonArray.add(entry.getKey());
+                }
+            }
+        } else {
+            jsonArray.addAll(dataMap.keySet());
+        }
+
+        if (enclosingElement != null) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(enclosingElement, jsonArray);
+            return jsonObject;
+        }
+
+        return jsonArray;
+    }
+
+    class ExtensionState extends State {
+
+        private final Map<String, Object> state = new HashMap<>();
+
+        @Override
+        public boolean canDestroy() {
+            return dataMap.isEmpty();
+        }
+
+        @Override
+        public Map<String, Object> snapshot() {
+            return state;
+        }
+
+        @Override
+        public void restore(Map<String, Object> map) {
+            dataMap = (Map<Object, Integer>) map.get(KEY_DATA_MAP);
+        }
+
+        private ExtensionState() {
+            state.put(KEY_DATA_MAP, dataMap);
+        }
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAsStringAggregatorFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAsStringAggregatorFunctionExtension.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.execution.json.function;
+
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.annotation.Parameter;
+import io.siddhi.annotation.ParameterOverload;
+import io.siddhi.annotation.ReturnAttribute;
+import io.siddhi.annotation.util.DataType;
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.executor.ExpressionExecutor;
+import io.siddhi.core.query.processor.ProcessingMode;
+import io.siddhi.core.query.selector.attribute.aggregator.AttributeAggregatorExecutor;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.query.api.definition.Attribute;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+import static io.siddhi.query.api.definition.Attribute.Type.STRING;
+
+/**
+ * groupAsString(json, enclosing.element)
+ * Returns JSON object as String by merging all JSON elements if enclosing element is provided.
+ * Returns a JSON array as String by adding all JSON elements if enclosing element is not provided
+ */
+@Extension(
+        name = "groupAsString",
+        namespace = "json",
+        description = "This function aggregates the JSON elements and returns a JSON object by adding " +
+                "enclosing.element if it is provided. If enclosing.element is not provided it aggregate the JSON " +
+                "elements returns a JSON array.",
+        parameters = {
+                @Parameter(name = "json",
+                        description = "The JSON element that needs to be aggregated.",
+                        type = {DataType.STRING},
+                        dynamic = true),
+                @Parameter(name = "enclosing.element",
+                        description = "The JSON element used to enclose the aggregated JSON elements.",
+                        type = {DataType.STRING}, optional = true, defaultValue = "EMPTY_STRING", dynamic = true),
+                @Parameter(name = "distinct",
+                        description = "This is used to only have distinct JSON elements in the concatenated " +
+                                "JSON object/array that is returned.",
+                        type = {DataType.BOOL}, optional = true, defaultValue = "false", dynamic = true)
+        },
+        parameterOverloads = {
+                @ParameterOverload(parameterNames = {"json"}),
+                @ParameterOverload(parameterNames = {"json", "distinct"}),
+                @ParameterOverload(parameterNames = {"json", "enclosing.element"}),
+                @ParameterOverload(parameterNames = {"json", "enclosing.element", "distinct"})
+        },
+        returnAttributes = @ReturnAttribute(
+                description = "This returns a JSON object if enclosing element is provided. If there is no enclosing " +
+                        "element then it returns a JSON array.",
+                type = {DataType.OBJECT}),
+        examples = {
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\") as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"12:20\"}`, it" +
+                                " returns `[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}" +
+                                "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}]` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", true) as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}`, it" +
+                                " returns `[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}]` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", \"result\") as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"12:20\"}`, it" +
+                                " returns `{\"result\":[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}," +
+                                "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}}` to the 'OutputStream'."),
+                @Example(
+                        syntax = "from InputStream#window.length(5)\n" +
+                                "select json:group(\"json\", \"result\", true) as groupedJSONArray\n" +
+                                "input OutputStream;",
+                        description = "When we input events having values for the `json` as " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}` and " +
+                                "`{\"date\":\"2013-11-19\",\"time\":\"10:30\"}`, it" +
+                                " returns `{\"result\":[{\"date\":\"2013-11-19\",\"time\":\"10:30\"}]}` " +
+                                "to the 'OutputStream'.")
+        }
+
+)
+public class GroupAsStringAggregatorFunctionExtension
+        extends AttributeAggregatorExecutor<GroupAsStringAggregatorFunctionExtension.ExtensionState> {
+
+    private static final String KEY_DATA_MAP = "dataMap";
+    private Map<Object, Integer> dataMap = new LinkedHashMap<>();
+
+    @Override
+    protected StateFactory<ExtensionState> init(ExpressionExecutor[] expressionExecutors,
+                                                ProcessingMode processingMode,
+                                                boolean b,
+                                                ConfigReader configReader,
+                                                SiddhiQueryContext siddhiQueryContext) {
+        return () -> new ExtensionState();
+    }
+
+    @Override
+    public Object processAdd(Object o, ExtensionState extensionState) {
+        addJSONElement(o);
+        return constructJSONString(null, false);
+    }
+
+    @Override
+    public Object processAdd(Object[] objects, ExtensionState extensionState) {
+        addJSONElement(objects[0]);
+        return processJSONObject(objects);
+    }
+
+    @Override
+    public Object processRemove(Object o, ExtensionState extensionState) {
+        removeJSONElement(o);
+        return constructJSONString(null, false);
+    }
+
+    @Override
+    public Object processRemove(Object[] objects, ExtensionState extensionState) {
+        removeJSONElement(objects[0]);
+        return processJSONObject(objects);
+    }
+
+    @Override
+    public Object reset(ExtensionState extensionState) {
+        dataMap.clear();
+        return null;
+    }
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return STRING;
+    }
+
+    private Object processJSONObject(Object[] objects) {
+        if (objects.length == 3) {
+            return constructJSONString(objects[1].toString(), Boolean.parseBoolean(objects[2].toString()));
+        } else {
+            if (objects[1] instanceof Boolean) {
+                return constructJSONString(null, Boolean.parseBoolean(objects[1].toString()));
+            } else {
+                return constructJSONString(objects[1].toString(), false);
+            }
+        }
+
+    }
+
+    private void addJSONElement(Object json) {
+        Integer count = dataMap.get(json);
+        dataMap.put(json, (count == null) ? 1 : count + 1);
+    }
+
+    private void removeJSONElement(Object json) {
+        Integer count = dataMap.get(json);
+        if (count == 1) {
+            dataMap.remove(json);
+        } else if (count > 1) {
+            dataMap.put(json, count - 1);
+        }
+    }
+
+    private String constructJSONString(String enclosingElement, boolean isDistinct) {
+        JSONArray jsonArray = new JSONArray();
+        if (!isDistinct) {
+            for (Map.Entry<Object, Integer> entry : dataMap.entrySet()) {
+                for (int i = 0; i < entry.getValue(); i++) {
+                    jsonArray.add(entry.getKey());
+                }
+            }
+        } else {
+            jsonArray.addAll(dataMap.keySet());
+        }
+
+        if (enclosingElement != null) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(enclosingElement, jsonArray);
+            return jsonObject.toJSONString();
+        }
+
+        return jsonArray.toJSONString();
+    }
+
+    class ExtensionState extends State {
+
+        private final Map<String, Object> state = new HashMap<>();
+
+        @Override
+        public boolean canDestroy() {
+            return dataMap.isEmpty();
+        }
+
+        @Override
+        public Map<String, Object> snapshot() {
+            return state;
+        }
+
+        @Override
+        public void restore(Map<String, Object> map) {
+            dataMap = (Map<Object, Integer>) map.get(KEY_DATA_MAP);
+        }
+
+        private ExtensionState() {
+            state.put(KEY_DATA_MAP, dataMap);
+        }
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/execution/json/GroupAggregatorFunctionTestcase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/GroupAggregatorFunctionTestcase.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.execution.json;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GroupAggregatorFunctionTestcase {
+
+    private static final Logger LOGGER = Logger.getLogger(GroupAggregatorFunctionTestcase.class);
+    private AtomicInteger count = new AtomicInteger(0);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+    }
+
+    @Test
+    public void testAggregateFunctionExtension1() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension1 TestCase - JSON as String Input");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:group(symbol1) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        String jsonString2 = "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        jsonArray.add(jsonString2);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"12:20\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension1"})
+    public void testAggregateFunctionExtension2() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension2 TestCase - JSON as String Input");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:group(symbol1) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONObject jsonObject2 = new JSONObject();
+                        jsonObject2.put("date", "2013-11-19");
+                        jsonObject2.put("time", "12:20");
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+                        jsonArray.add(jsonObject2);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "12:20");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension2"})
+    public void testAggregateFunctionExtension3() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension3 TestCase - JSON enclosing element");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(3) " +
+                "select json:group(symbol1, 'result') as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        String jsonString2 = "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        jsonArray.add(jsonString2);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"12:20\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension3"})
+    public void testAggregateFunctionExtension4() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension4 TestCase - Distinct");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(3) " +
+                "select json:group(symbol1, true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension4"})
+    public void testAggregateFunctionExtension5() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension5 TestCase - Enclosing element & distinct");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:group(symbol1, 'result', true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "10:30");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension5"})
+    public void testAggregateFunctionExtension6() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension5 TestCase - with window expiry");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(2) " +
+                "select json:group(symbol1, 'result', true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+
+                    if (count.get() == 4) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONObject jsonObject3 = new JSONObject();
+                        jsonObject3.put("date", "2013-11-19");
+                        jsonObject3.put("time", "12:20");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(jsonObject1);
+                        jsonArray.add(jsonObject3);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "10:30");
+
+        JSONObject jsonObject3 = new JSONObject();
+        jsonObject3.put("date", "2013-11-19");
+        jsonObject3.put("time", "12:20");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        inputHandler.send(new Object[]{jsonObject3});
+        SiddhiTestHelper.waitForEvents(100, 4, count, 60000);
+        AssertJUnit.assertEquals(4, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/execution/json/GroupAsStringAggregatorFunctionTestcase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/GroupAsStringAggregatorFunctionTestcase.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.execution.json;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GroupAsStringAggregatorFunctionTestcase {
+
+    private static final Logger LOGGER = Logger.getLogger(GroupAsStringAggregatorFunctionTestcase.class);
+    private AtomicInteger count = new AtomicInteger(0);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+    }
+
+    @Test
+    public void testAggregateFunctionExtension1() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension1 TestCase - JSON as String Input");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:groupAsString(symbol1) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        String jsonString2 = "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        jsonArray.add(jsonString2);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"12:20\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension1"})
+    public void testAggregateFunctionExtension2() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension2 TestCase - JSON as String Input");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:groupAsString(symbol1) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONObject jsonObject2 = new JSONObject();
+                        jsonObject2.put("date", "2013-11-19");
+                        jsonObject2.put("time", "12:20");
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+                        jsonArray.add(jsonObject2);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "12:20");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension2"})
+    public void testAggregateFunctionExtension3() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension3 TestCase - JSON enclosing element");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(3) " +
+                "select json:groupAsString(symbol1, 'result') as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        String jsonString2 = "{\"date\":\"2013-11-19\",\"time\":\"12:20\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        jsonArray.add(jsonString2);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"12:20\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension3"})
+    public void testAggregateFunctionExtension4() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension4 TestCase - Distinct");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(3) " +
+                "select json:groupAsString(symbol1, true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        String jsonString = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        String jsonString1 = "{\"date\":\"2013-11-19\",\"time\":\"10:30\"}";
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonString1);
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        inputHandler.send(new Object[]{"{\"date\":\"2013-11-19\",\"time\":\"10:30\"}"});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension4"})
+    public void testAggregateFunctionExtension5() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension5 TestCase - Enclosing element & distinct");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream " +
+                "select json:groupAsString(symbol1, 'result', true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "10:30");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        SiddhiTestHelper.waitForEvents(100, 3, count, 60000);
+        AssertJUnit.assertEquals(3, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test(dependsOnMethods = {"testAggregateFunctionExtension5"})
+    public void testAggregateFunctionExtension6() throws InterruptedException {
+        LOGGER.info("TestAggregateFunctionExtension5 TestCase - with window expiry");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream#window.length(2) " +
+                "select json:groupAsString(symbol1, 'result', true) as concatJSON " +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    if (count.get() == 1) {
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 2) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(null);
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                    if (count.get() == 3) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(jsonObject1);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+
+                    if (count.get() == 4) {
+                        JSONObject jsonObject1 = new JSONObject();
+                        jsonObject1.put("date", "2013-11-19");
+                        jsonObject1.put("time", "10:30");
+
+                        JSONObject jsonObject3 = new JSONObject();
+                        jsonObject3.put("date", "2013-11-19");
+                        jsonObject3.put("time", "12:20");
+
+                        JSONArray jsonArray = new JSONArray();
+                        jsonArray.add(jsonObject1);
+                        jsonArray.add(jsonObject3);
+
+                        JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("result", jsonArray);
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        eventArrived = true;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("date", "2013-11-19");
+        jsonObject1.put("time", "10:30");
+
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("date", "2013-11-19");
+        jsonObject2.put("time", "10:30");
+
+        JSONObject jsonObject3 = new JSONObject();
+        jsonObject3.put("date", "2013-11-19");
+        jsonObject3.put("time", "12:20");
+
+        inputHandler.send(new Object[]{null});
+        inputHandler.send(new Object[]{jsonObject1});
+        inputHandler.send(new Object[]{jsonObject2});
+        inputHandler.send(new Object[]{jsonObject3});
+        SiddhiTestHelper.waitForEvents(100, 4, count, 60000);
+        AssertJUnit.assertEquals(4, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+}

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -17,6 +17,8 @@
             <class name="io.siddhi.extension.execution.json.ToStringFunctionTestCase"/>
             <class name="io.siddhi.extension.execution.json.SetElementJSONFunctionTestCase"/>
             <class name="io.siddhi.extension.execution.json.JsonTokenizerAsObjectStreamProcessorFunctionTestCase"/>
+            <class name="io.siddhi.extension.execution.json.GroupAggregatorFunctionTestcase"/>
+            <class name="io.siddhi.extension.execution.json.GroupAsStringAggregatorFunctionTestcase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> To provide JSON grouping support.. Fixes https://github.com/siddhi-io/siddhi-execution-json/issues/24

Below are the possible syntaxes supported for json:group extension
```
json:group(<STRING|OBJECT> json) 
json:group(<STRING|OBJECT> json, <STRING>enclosingElement)
json:group(<STRING|OBJECT> json, <BOOLEAN>distinct)
json:group(<STRING|OBJECT> json, <STRING>enclosingElement, <BOOLEAN>distinct)

```

Below are the possible syntaxes supported for json:groupAsString extension
```
json:groupAsString(<STRING|OBJECT> json) 
json:groupAsString(<STRING|OBJECT> json, <STRING>enclosingElement)
json:groupAsString(<STRING|OBJECT> json, <BOOLEAN>distinct)
json:groupAsString(<STRING|OBJECT> json, <STRING>enclosingElement, <BOOLEAN>distinct)

```