### PR TITLE
Rename group functions and related refactoring changes

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAggregatorFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/json/function/GroupAggregatorFunctionExtension.java
@@ -39,12 +39,13 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static io.siddhi.query.api.definition.Attribute.Type.OBJECT;
+
+import static io.siddhi.query.api.definition.Attribute.Type.STRING;
 
 /**
- * group(json, enclosing.element)
- * Returns JSON object by merging all JSON elements if enclosing element is provided.
- * Returns a JSON array by adding all JSON elements if enclosing element is not provided
+ * group(json, enclosing.element, distinct)
+ * Returns JSON object as String by merging all JSON elements if enclosing element is provided.
+ * Returns a JSON array as String by adding all JSON elements if enclosing element is not provided
  */
 @Extension(
         name = "group",
@@ -132,7 +133,7 @@ public class GroupAggregatorFunctionExtension
     @Override
     public Object processAdd(Object o, ExtensionState extensionState) {
         addJSONElement(o);
-        return constructJSONObject(null, false);
+        return constructJSONString(null, false);
     }
 
     @Override
@@ -144,7 +145,7 @@ public class GroupAggregatorFunctionExtension
     @Override
     public Object processRemove(Object o, ExtensionState extensionState) {
         removeJSONElement(o);
-        return constructJSONObject(null, false);
+        return constructJSONString(null, false);
     }
 
     @Override
@@ -161,17 +162,17 @@ public class GroupAggregatorFunctionExtension
 
     @Override
     public Attribute.Type getReturnType() {
-        return OBJECT;
+        return STRING;
     }
 
     private Object processJSONObject(Object[] objects) {
         if (objects.length == 3) {
-            return constructJSONObject(objects[1].toString(), Boolean.parseBoolean(objects[2].toString()));
+            return constructJSONString(objects[1].toString(), Boolean.parseBoolean(objects[2].toString()));
         } else {
             if (objects[1] instanceof Boolean) {
-                return constructJSONObject(null, Boolean.parseBoolean(objects[1].toString()));
+                return constructJSONString(null, Boolean.parseBoolean(objects[1].toString()));
             } else {
-                return constructJSONObject(objects[1].toString(), false);
+                return constructJSONString(objects[1].toString(), false);
             }
         }
 
@@ -191,7 +192,7 @@ public class GroupAggregatorFunctionExtension
         }
     }
 
-    private Object constructJSONObject(String enclosingElement, boolean isDistinct) {
+    private String constructJSONString(String enclosingElement, boolean isDistinct) {
         JSONArray jsonArray = new JSONArray();
         if (!isDistinct) {
             for (Map.Entry<Object, Integer> entry : dataMap.entrySet()) {
@@ -206,10 +207,10 @@ public class GroupAggregatorFunctionExtension
         if (enclosingElement != null) {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put(enclosingElement, jsonArray);
-            return jsonObject;
+            return jsonObject.toJSONString();
         }
 
-        return jsonArray;
+        return jsonArray.toJSONString();
     }
 
     class ExtensionState extends State {

--- a/component/src/test/java/io/siddhi/extension/execution/json/GroupAggregatorFunctionTestcase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/GroupAggregatorFunctionTestcase.java
@@ -67,7 +67,7 @@ public class GroupAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -75,7 +75,7 @@ public class GroupAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -85,7 +85,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         jsonArray.add(jsonString1);
                         jsonArray.add(jsonString2);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -124,7 +124,7 @@ public class GroupAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -134,7 +134,7 @@ public class GroupAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonObject1);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -149,7 +149,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         jsonArray.add(jsonObject1);
                         jsonArray.add(jsonObject2);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -199,7 +199,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -209,7 +209,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(jsonString);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -221,7 +221,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(jsonString2);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -260,7 +260,7 @@ public class GroupAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -268,7 +268,7 @@ public class GroupAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -276,7 +276,7 @@ public class GroupAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString1);
-                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -317,7 +317,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -331,7 +331,7 @@ public class GroupAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -345,7 +345,7 @@ public class GroupAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -395,7 +395,7 @@ public class GroupAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -409,7 +409,7 @@ public class GroupAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -422,7 +422,7 @@ public class GroupAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
 
@@ -441,7 +441,7 @@ public class GroupAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
                         eventArrived = true;
                     }
                 }

--- a/component/src/test/java/io/siddhi/extension/execution/json/GroupAsObjectAggregatorFunctionTestcase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/GroupAsObjectAggregatorFunctionTestcase.java
@@ -34,9 +34,9 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class GroupAsStringAggregatorFunctionTestcase {
+public class GroupAsObjectAggregatorFunctionTestcase {
 
-    private static final Logger LOGGER = Logger.getLogger(GroupAsStringAggregatorFunctionTestcase.class);
+    private static final Logger LOGGER = Logger.getLogger(GroupAsObjectAggregatorFunctionTestcase.class);
     private AtomicInteger count = new AtomicInteger(0);
     private volatile boolean eventArrived;
 
@@ -54,7 +54,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
-                "select json:groupAsString(symbol1) as concatJSON " +
+                "select json:groupAsObject(symbol1) as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -67,7 +67,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -75,7 +75,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -85,7 +85,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         jsonArray.add(jsonString1);
                         jsonArray.add(jsonString2);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -111,7 +111,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
-                "select json:groupAsString(symbol1) as concatJSON " +
+                "select json:groupAsObject(symbol1) as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -124,7 +124,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -134,7 +134,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonObject1);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -149,7 +149,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         jsonArray.add(jsonObject1);
                         jsonArray.add(jsonObject2);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -184,7 +184,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream#window.length(3) " +
-                "select json:groupAsString(symbol1, 'result') as concatJSON " +
+                "select json:groupAsObject(symbol1, 'result') as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -199,7 +199,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -209,7 +209,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(jsonString);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -221,7 +221,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(jsonString2);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -247,7 +247,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream#window.length(3) " +
-                "select json:groupAsString(symbol1, true) as concatJSON " +
+                "select json:groupAsObject(symbol1, true) as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -260,7 +260,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                     if (count.get() == 1) {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -268,7 +268,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -276,7 +276,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         JSONArray jsonArray = new JSONArray();
                         jsonArray.add(null);
                         jsonArray.add(jsonString1);
-                        AssertJUnit.assertEquals(jsonArray.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonArray, event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -302,7 +302,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream " +
-                "select json:groupAsString(symbol1, 'result', true) as concatJSON " +
+                "select json:groupAsObject(symbol1, 'result', true) as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -317,7 +317,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -331,7 +331,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -345,7 +345,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                 }
@@ -380,7 +380,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
         String inStreamDefinition = "define stream inputStream (symbol1 string, symbol2 string, symbol3 string);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream#window.length(2) " +
-                "select json:groupAsString(symbol1, 'result', true) as concatJSON " +
+                "select json:groupAsObject(symbol1, 'result', true) as concatJSON " +
                 "insert into outputStream;");
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
 
@@ -395,7 +395,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
                         jsonArray.add(null);
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 2) {
@@ -409,7 +409,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
@@ -422,7 +422,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
 
@@ -441,7 +441,7 @@ public class GroupAsStringAggregatorFunctionTestcase {
 
                         JSONObject jsonObject = new JSONObject();
                         jsonObject.put("result", jsonArray);
-                        AssertJUnit.assertEquals(jsonObject.toJSONString(), event.getData(0));
+                        AssertJUnit.assertEquals(jsonObject, event.getData(0));
                         eventArrived = true;
                     }
                 }

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -17,8 +17,8 @@
             <class name="io.siddhi.extension.execution.json.ToStringFunctionTestCase"/>
             <class name="io.siddhi.extension.execution.json.SetElementJSONFunctionTestCase"/>
             <class name="io.siddhi.extension.execution.json.JsonTokenizerAsObjectStreamProcessorFunctionTestCase"/>
+            <class name="io.siddhi.extension.execution.json.GroupAsObjectAggregatorFunctionTestcase"/>
             <class name="io.siddhi.extension.execution.json.GroupAggregatorFunctionTestcase"/>
-            <class name="io.siddhi.extension.execution.json.GroupAsStringAggregatorFunctionTestcase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> $subject.. 

Below are the new syntaxes..

```
json:group(<STRING|OBJECT> json) 
json:group(<STRING|OBJECT> json, <STRING>enclosingElement)
json:group(<STRING|OBJECT> json, <BOOLEAN>distinct)
json:group(<STRING|OBJECT> json, <STRING>enclosingElement, <BOOLEAN>distinct)

```

```
json:groupAsObject(<STRING|OBJECT> json) 
json:groupAsObject(<STRING|OBJECT> json, <STRING>enclosingElement)
json:groupAsObject(<STRING|OBJECT> json, <BOOLEAN>distinct)
json:groupAsObject(<STRING|OBJECT> json, <STRING>enclosingElement, <BOOLEAN>distinct)

```