### PR TITLE
Introduce allow.escape parameter to toString() function

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/json/function/ToJSONStringFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/json/function/ToJSONStringFunctionExtension.java
@@ -53,7 +53,8 @@ import org.apache.log4j.Logger;
                         dynamic = true),
                 @Parameter(
                         name = "allow.escape",
-                        description = "TODO.",
+                        description = "If this is set to true, quotes will be escaped in the resulting string. " +
+                                "Otherwise quotes will not be escaped.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "false",
@@ -66,10 +67,23 @@ import org.apache.log4j.Logger;
         returnAttributes = @ReturnAttribute(
                 description = "Returns the JSON string for the given JSON object.",
                 type = {DataType.STRING}),
-        examples = @Example(
+        examples = {
+        @Example(
                 syntax = "json:toString(json)",
                 description = "This returns the JSON string corresponding to a given JSON object."
-        )
+        ),
+        @Example(
+                syntax = "json:toString(json, true)",
+                description = "Assume the json object has the field 'user' with value 'david'. " +
+                        "With the allowEscape parameter set to true, this will return the string " +
+                        "\"{\\\"user\\\":\\\"david\\\"}\""),
+        @Example(
+                syntax = "json:toString(json, false)",
+                description = "Assume the json object has the field 'user' with value 'david'. " +
+                        "With the allowEscape parameter set to false, this will return the string " +
+                        "{\"user\":\"david\"}"),
+        }
+
 )
 public class ToJSONStringFunctionExtension extends FunctionExecutor {
     private static final Logger log = Logger.getLogger(ToJSONStringFunctionExtension.class);

--- a/component/src/main/java/io/siddhi/extension/execution/json/function/ToJSONStringFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/json/function/ToJSONStringFunctionExtension.java
@@ -61,7 +61,7 @@ import org.apache.log4j.Logger;
         },
         parameterOverloads = {
                 @ParameterOverload(parameterNames = {"json"}),
-                @ParameterOverload(parameterNames = {"json","allow.escape"})
+                @ParameterOverload(parameterNames = {"json", "allow.escape"})
         },
         returnAttributes = @ReturnAttribute(
                 description = "Returns the JSON string for the given JSON object.",
@@ -103,16 +103,16 @@ public class ToJSONStringFunctionExtension extends FunctionExecutor {
                     "json:toString() function, required " + Attribute.Type.OBJECT + ", but found " + firstAttributeType
                     .toString());
         }
-        if (attributeExpressionExecutors.length == 2){
+        if (attributeExpressionExecutors.length == 2) {
             if (attributeExpressionExecutors[1] == null) {
                 throw new SiddhiAppValidationException("Invalid input given to first argument 'allowEscape' of " +
                         "json:toString() function. Input for 'allowEscape' argument cannot be null");
             }
             Attribute.Type secondAttributeType = attributeExpressionExecutors[1].getReturnType();
             if (secondAttributeType != Attribute.Type.BOOL) {
-                throw new SiddhiAppValidationException("Invalid parameter type found for the second argument 'allowEscape' of " +
-                        "json:toString() function, required " + Attribute.Type.BOOL + ", but found " + secondAttributeType
-                        .toString());
+                throw new SiddhiAppValidationException("Invalid parameter type found for the second argument " +
+                        "'allowEscape' of json:toString() function, required " + Attribute.Type.BOOL +
+                        ", but found " + secondAttributeType.toString());
             }
         }
 

--- a/component/src/test/java/io/siddhi/extension/execution/json/ToStringFunctionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/ToStringFunctionTestCase.java
@@ -79,4 +79,208 @@ public class ToStringFunctionTestCase {
         inputHandler.send(new Object[]{jsonObject});
         siddhiAppRuntime.shutdown();
     }
+
+    @Test
+    public void testToStringFunctionWithAllowEscapeTrueSimple() throws InterruptedException, ParseException {
+        log.info("ToStringFunctionTestCase - testToStringFunctionWithAllowEscapeTrueSimple");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(data object, allowEscape bool);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:toString(data, allowEscape) as json\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals("\"{\\\"user\\\":\\\"david\\\"}\"", event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+
+        JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+        JSONObject jsonObject = (JSONObject) jsonParser.parse("{ \"user\":\"david\"}");
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{jsonObject, true});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testToStringFunctionWithAllowEscapeFalseSimple() throws InterruptedException, ParseException {
+        log.info("ToStringFunctionTestCase - testToStringFunctionWithAllowEscapeFalseSimple");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(data object, allowEscape bool);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:toString(data, allowEscape) as json\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals("{\"user\":\"david\"}", event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+
+        JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+        JSONObject jsonObject = (JSONObject) jsonParser.parse("{ \"user\":\"david\"}");
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{jsonObject, false});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testToStringFunctionWithAllowEscape() throws InterruptedException, ParseException {
+        log.info("ToStringFunctionTestCase - testToStringFunctionWithAllowEscape");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(data object, allowEscape bool);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:toString(data, allowEscape) as json\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals("\"{\\\"citizen\\\":false,\\\"bar\\\":[{\\\"barName\\\":\\\"barName\\\"},{\\\"barName\\\":\\\"barName2\\\"}],\\\"name\\\":\\\"John\\\",\\\"age\\\":25}\"", event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+
+        JSONParser jsonParser = new JSONParser(JSONParser.DEFAULT_PERMISSIVE_MODE);
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(JSON_INPUT);
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{jsonObject, true});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testToStringFunctionWithAllowEscapeTrue() throws InterruptedException, ParseException {
+        log.info("ToStringFunctionTestCase - testToStringFunctionWithAllowEscapeTrue");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(data string, allowEscape bool);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:toString(json:toObject(data), allowEscape) as json\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals("\"{\\\"accounting\\\":[{\\\"firstName\\\":\\\"John\\\",\\\"lastName\\\":\\\"Doe\\\",\\\"age\\\":23},{\\\"firstName\\\":\\\"Mary\\\",\\\"lastName\\\":\\\"Smith\\\",\\\"age\\\":32}],\\\"sales\\\":[{\\\"firstName\\\":\\\"Sally\\\",\\\"lastName\\\":\\\"Green\\\",\\\"age\\\":27},{\\\"firstName\\\":\\\"Jim\\\",\\\"lastName\\\":\\\"Galley\\\",\\\"age\\\":41}]}\"", event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{"{ \n" +
+                "  \"accounting\" : [   \n" +
+                "                     { \"firstName\" : \"John\",  \n" +
+                "                       \"lastName\"  : \"Doe\",\n" +
+                "                       \"age\"       : 23 },\n" +
+                "\n" +
+                "                     { \"firstName\" : \"Mary\",  \n" +
+                "                       \"lastName\"  : \"Smith\",\n" +
+                "                        \"age\"      : 32 }\n" +
+                "                 ],                            \n" +
+                "  \"sales\"      : [ \n" +
+                "                     { \"firstName\" : \"Sally\", \n" +
+                "                       \"lastName\"  : \"Green\",\n" +
+                "                        \"age\"      : 27 },\n" +
+                "\n" +
+                "                     { \"firstName\" : \"Jim\",   \n" +
+                "                       \"lastName\"  : \"Galley\",\n" +
+                "                       \"age\"       : 41 }\n" +
+                "                 ] \n" +
+                "}", true});
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testToStringFunctionWithAllowEscapeFalse() throws InterruptedException, ParseException {
+        log.info("ToStringFunctionTestCase - testToStringFunctionWithAllowEscapeFalse");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream InputStream(data string, allowEscape bool);\n";
+        String query = ("@info(name = 'query1')\n" +
+                "from InputStream\n" +
+                "select json:toString(json:toObject(data), allowEscape) as json\n" +
+                "insert into OutputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals("{\"accounting\":[{\"firstName\":\"John\",\"lastName\":\"Doe\",\"age\":23},{\"firstName\":\"Mary\",\"lastName\":\"Smith\",\"age\":32}],\"sales\":[{\"firstName\":\"Sally\",\"lastName\":\"Green\",\"age\":27},{\"firstName\":\"Jim\",\"lastName\":\"Galley\",\"age\":41}]}", event.getData(0));
+                            break;
+                    }
+                }
+            }
+        });
+
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{"{ \n" +
+                "  \"accounting\" : [   \n" +
+                "                     { \"firstName\" : \"John\",  \n" +
+                "                       \"lastName\"  : \"Doe\",\n" +
+                "                       \"age\"       : 23 },\n" +
+                "\n" +
+                "                     { \"firstName\" : \"Mary\",  \n" +
+                "                       \"lastName\"  : \"Smith\",\n" +
+                "                        \"age\"      : 32 }\n" +
+                "                 ],                            \n" +
+                "  \"sales\"      : [ \n" +
+                "                     { \"firstName\" : \"Sally\", \n" +
+                "                       \"lastName\"  : \"Green\",\n" +
+                "                        \"age\"      : 27 },\n" +
+                "\n" +
+                "                     { \"firstName\" : \"Jim\",   \n" +
+                "                       \"lastName\"  : \"Galley\",\n" +
+                "                       \"age\"       : 41 }\n" +
+                "                 ] \n" +
+                "}", false});
+        siddhiAppRuntime.shutdown();
+    }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/json/ToStringFunctionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/ToStringFunctionTestCase.java
@@ -167,7 +167,9 @@ public class ToStringFunctionTestCase {
                     count.incrementAndGet();
                     switch (count.get()) {
                         case 1:
-                            AssertJUnit.assertEquals("\"{\\\"citizen\\\":false,\\\"bar\\\":[{\\\"barName\\\":\\\"barName\\\"},{\\\"barName\\\":\\\"barName2\\\"}],\\\"name\\\":\\\"John\\\",\\\"age\\\":25}\"", event.getData(0));
+                            AssertJUnit.assertEquals("\"{\\\"citizen\\\":false,\\\"bar\\\":[{\\\"barName\\\"" +
+                                    ":\\\"barName\\\"},{\\\"barName\\\":\\\"barName2\\\"}],\\\"name\\\":\\\"John\\\"" +
+                                    ",\\\"age\\\":25}\"", event.getData(0));
                             break;
                     }
                 }
@@ -201,7 +203,12 @@ public class ToStringFunctionTestCase {
                     count.incrementAndGet();
                     switch (count.get()) {
                         case 1:
-                            AssertJUnit.assertEquals("\"{\\\"accounting\\\":[{\\\"firstName\\\":\\\"John\\\",\\\"lastName\\\":\\\"Doe\\\",\\\"age\\\":23},{\\\"firstName\\\":\\\"Mary\\\",\\\"lastName\\\":\\\"Smith\\\",\\\"age\\\":32}],\\\"sales\\\":[{\\\"firstName\\\":\\\"Sally\\\",\\\"lastName\\\":\\\"Green\\\",\\\"age\\\":27},{\\\"firstName\\\":\\\"Jim\\\",\\\"lastName\\\":\\\"Galley\\\",\\\"age\\\":41}]}\"", event.getData(0));
+                            AssertJUnit.assertEquals("\"{\\\"accounting\\\":[{\\\"firstName\\\":\\\"John\\\"," +
+                                    "\\\"lastName\\\":\\\"Doe\\\",\\\"age\\\":23},{\\\"firstName\\\":\\\"Mary\\\"," +
+                                    "\\\"lastName\\\":\\\"Smith\\\",\\\"age\\\":32}],\\\"sales\\\":[{\\\"firstName" +
+                                    "\\\":\\\"Sally\\\",\\\"lastName\\\":\\\"Green\\\",\\\"age\\\":27},{\\\"" +
+                                    "firstName\\\":\\\"Jim\\\",\\\"lastName\\\":\\\"Galley\\\",\\\"age\\\":41}]}\"",
+                                    event.getData(0));
                             break;
                     }
                 }
@@ -252,7 +259,11 @@ public class ToStringFunctionTestCase {
                     count.incrementAndGet();
                     switch (count.get()) {
                         case 1:
-                            AssertJUnit.assertEquals("{\"accounting\":[{\"firstName\":\"John\",\"lastName\":\"Doe\",\"age\":23},{\"firstName\":\"Mary\",\"lastName\":\"Smith\",\"age\":32}],\"sales\":[{\"firstName\":\"Sally\",\"lastName\":\"Green\",\"age\":27},{\"firstName\":\"Jim\",\"lastName\":\"Galley\",\"age\":41}]}", event.getData(0));
+                            AssertJUnit.assertEquals("{\"accounting\":[{\"firstName\":\"John\",\"lastName\"" +
+                                    ":\"Doe\",\"age\":23},{\"firstName\":\"Mary\",\"lastName\":\"Smith\",\"age\"" +
+                                    ":32}],\"sales\":[{\"firstName\":\"Sally\",\"lastName\":\"Green\",\"age\":27}," +
+                                    "{\"firstName\":\"Jim\",\"lastName\":\"Galley\",\"age\":41}]}",
+                                    event.getData(0));
                             break;
                     }
                 }


### PR DESCRIPTION
## Purpose
Introduce allow.escape parameter to toString() function.

## Goals
Include escape literal in the resulting string.

## Approach
Use `json:toString(json, true)` when you want to produce the string with escape charaters.

## User stories
As a user, I want to produce a string with escape literals out of a json object.

## Release note
Introduce allow.escape parameter to json:toString() function. This allows a user to produce a string with escape literals out of a json object.

## Documentation
Included.

## Automation tests
Unit tests available.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
N/A