### PR TITLE
Bump json-path version to 2.9.0 and json-smart version to 2.5.0

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>json-path</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -91,13 +95,11 @@
                             io.siddhi.extension.execution.json,
                             io.siddhi.extension.execution.json.*
                         </Export-Package>
-                        <Private-Package>
-                            com.jayway.jsonpath.*,
-                            net.minidev.*
-                        </Private-Package>
                         <Import-Package>
                             io.siddhi.core.*;version="${siddhi.version.range}",
                             io.siddhi.query.api.*;version="${siddhi.version.range}",
+                            com.jayway.jsonpath.*;version="${com.jayway.jsonpath.version.range}",
+                            net.minidev.*;version="${net.minidev.json-smart.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/component/src/test/java/io/siddhi/extension/execution/json/SetElementJSONFunctionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/json/SetElementJSONFunctionTestCase.java
@@ -390,7 +390,7 @@ public class SetElementJSONFunctionTestCase {
                 "@info(name = 'query1')\n" +
                         "from InputStream\n" +
                         "select json:setElement(\"{'name' : 'Stationary', 'item' : 'pen'}\", " +
-                        "                           '$.item', 'book', 'item') as newJson\n" +
+                        "                           '$', 'book', 'item') as newJson\n" +
                         "insert into OutputStream;";
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
         siddhiAppRuntime.addCallback("query1", new QueryCallback() {
@@ -411,7 +411,7 @@ public class SetElementJSONFunctionTestCase {
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("InputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"test"});
-        AssertJUnit.assertEquals(0, count.get());
+        AssertJUnit.assertEquals(1, count.get());
         siddhiAppRuntime.shutdown();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,11 @@
     <properties>
         <siddhi.version>5.1.21</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
+        <com.jayway.jsonpath.version.range>[2.2.0,3.0.0)</com.jayway.jsonpath.version.range>
+        <net.minidev.json-smart.version.range>[2.5.0,3.0.0)</net.minidev.json-smart.version.range>
         <log4j.version>2.17.1</log4j.version>
-        <com.jayway.jsonpath.version>2.2.0</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
+        <net.minidev.jsonsmart.version>2.5.0</net.minidev.jsonsmart.version>
         <testng.version>6.11</testng.version>
         <jacoco.maven.version>0.7.8</jacoco.maven.version>
     </properties>
@@ -54,6 +57,11 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${net.minidev.jsonsmart.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Purpose
This PR adds the following changes,

- Bump json-path version to 2.9.0
- Bump json-smart version to 2.5.0
- Remove the private packaged json-path and json-smart dependencies
- Handle JsonPathException when updating the DocumentContext in setElementJson
- Fix testSetElement3 test case to adhere to newly added exception handling